### PR TITLE
Error pointers initialization

### DIFF
--- a/Example/IrohaCommunication.xcodeproj/project.pbxproj
+++ b/Example/IrohaCommunication.xcodeproj/project.pbxproj
@@ -677,7 +677,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-IntegrationTestHost/Pods-IntegrationTestHost-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-IntegrationTestHost/Pods-IntegrationTestHost-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/BoringSSL/openssl.framework",
 				"${BUILT_PRODUCTS_DIR}/IrohaCommunication/IrohaCommunication.framework",
 				"${BUILT_PRODUCTS_DIR}/IrohaCrypto/IrohaCrypto.framework",
@@ -704,7 +704,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-IntegrationTestHost/Pods-IntegrationTestHost-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IntegrationTestHost/Pods-IntegrationTestHost-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		F038CD8710A254DFB6ADBE4A /* [CP] Embed Pods Frameworks */ = {
@@ -715,7 +715,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
-				"${SRCROOT}/Pods/Target Support Files/Pods-IrohaExample/Pods-IrohaExample-frameworks.sh",
+				"${PODS_ROOT}/Target Support Files/Pods-IrohaExample/Pods-IrohaExample-frameworks.sh",
 				"${BUILT_PRODUCTS_DIR}/BoringSSL/openssl.framework",
 				"${BUILT_PRODUCTS_DIR}/IrohaCommunication/IrohaCommunication.framework",
 				"${BUILT_PRODUCTS_DIR}/IrohaCrypto/IrohaCrypto.framework",
@@ -742,7 +742,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "\"${SRCROOT}/Pods/Target Support Files/Pods-IrohaExample/Pods-IrohaExample-frameworks.sh\"\n";
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-IrohaExample/Pods-IrohaExample-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -24,7 +24,7 @@ PODS:
   - gRPC/Main (1.11.0):
     - gRPC-Core (= 1.11.0)
     - gRPC-RxLibrary (= 1.11.0)
-  - IrohaCommunication (3.0.1):
+  - IrohaCommunication (3.0.2):
     - BoringSSL (= 10.0.3)
     - gRPC-ProtoRPC (= 1.11.0)
     - IrohaCrypto
@@ -62,11 +62,11 @@ SPEC CHECKSUMS:
   gRPC-Core: 164639cd8ae18ca8b65477fafb2efbaecf4f181a
   gRPC-ProtoRPC: bb5fddf3424aa4fad74d76736578a79fe40e244e
   gRPC-RxLibrary: 26d53d1b1f306befd4ad4e15bd6de27839a82481
-  IrohaCommunication: 72885dfed88423377a2ab522d8f62e11f5ee42a5
+  IrohaCommunication: c0b4767cd2ee741538cd37b5a8aa59c16a71af65
   IrohaCrypto: d0e6e1189ce43a51b6f7916f4830605c7d466d57
   nanopb: 5601e6bca2dbf1ed831b519092ec110f66982ca3
   Protobuf: 8a9838fba8dae3389230e1b7f8c104aa32389c03
 
 PODFILE CHECKSUM: 29089a97c3781ec366ef8266addf4289525ff849
 
-COCOAPODS: 1.5.3
+COCOAPODS: 1.6.1

--- a/IrohaCommunication/Classes/Public/Service/IRNetworkService.m
+++ b/IrohaCommunication/Classes/Public/Service/IRNetworkService.m
@@ -213,7 +213,7 @@
         return promise;
     }
 
-    NSError *error;
+    NSError *error = nil;
     Query *protobufQuery = [(id<IRProtobufTransformable>)queryRequest transform:&error];
 
     if (!protobufQuery) {

--- a/Tests/Model/IRAccountIdTests.m
+++ b/Tests/Model/IRAccountIdTests.m
@@ -54,7 +54,7 @@ static NSString * const VALID_DOMAIN = @"gmail.com";
 
 - (void)testInvalidAccountNamesWithError {
     for (NSUInteger i = 0; i < INVALID_ACCOUNT_NAMES_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRAccountId> accountId = [IRAccountIdFactory accountIdWithName:INVALID_ACCOUNT_NAMES[i]
                                                                    domain:[IRDomainFactory domainWithIdentitifer:VALID_DOMAIN error:nil]
                                                                     error:&error];
@@ -85,7 +85,7 @@ static NSString * const VALID_DOMAIN = @"gmail.com";
 
 - (void)testInvalidAccountIdentifierWithError {
     for (NSUInteger i = 0; i < INVALID_ACCOUNT_IDENTIFIERS_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRAccountId> accountId = [IRAccountIdFactory accountWithIdentifier:INVALID_ACCOUNT_IDENTIFIERS[i]
                                                                         error:&error];
         XCTAssertNil(accountId);

--- a/Tests/Model/IRAddressTests.m
+++ b/Tests/Model/IRAddressTests.m
@@ -71,7 +71,7 @@ static NSString * const INVALID_ADDRESS_DOMAINS[] = {
 
 - (void)testInvalidAddressWithError {
     for (NSUInteger i = 0; i < INVALID_ADDRESSES_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRAddress> address = [IRAddressFactory addressWithIp:INVALID_IPV4[i]
                                                            port:VALID_PORT
                                                           error:&error];
@@ -92,7 +92,7 @@ static NSString * const INVALID_ADDRESS_DOMAINS[] = {
 
 - (void)testInvalidIpPortWithError {
     for (NSUInteger i = 0; i < INVALID_PORTS_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRAddress> address = [IRAddressFactory addressWithIp:VALID_IPV4[0]
                                                            port:INVALID_PORTS[i]
                                                           error:&error];
@@ -126,7 +126,7 @@ static NSString * const INVALID_ADDRESS_DOMAINS[] = {
 
 - (void)testInvalidDomainWithError {
     for (NSUInteger i = 0; i < INVALID_ADDRESS_DOMAINS_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRAddress> address = [IRAddressFactory addressWithDomain:INVALID_ADDRESS_DOMAINS[i]
                                                                port:VALID_PORT
                                                               error:&error];
@@ -149,7 +149,7 @@ static NSString * const INVALID_ADDRESS_DOMAINS[] = {
 
 - (void)testInvalidDomainPortWithError {
     for (NSUInteger i = 0; i < INVALID_PORTS_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRAddress> address = [IRAddressFactory addressWithDomain:VALID_ADDRESS_DOMAINS[0]
                                                                port:INVALID_PORTS[i]
                                                               error:&error];

--- a/Tests/Model/IRAmountTests.m
+++ b/Tests/Model/IRAmountTests.m
@@ -40,7 +40,7 @@ static NSString * const INVALID_STRING_AMOUNT[] = {
 
 - (void)testInvalidStringAmountWithError {
     for (NSUInteger i = 0; i < INVALID_STRING_AMOUNT_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRAmount> amount = [IRAmountFactory amountFromString:INVALID_STRING_AMOUNT[i]
                                                           error:&error];
 

--- a/Tests/Model/IRAssetIdTests.m
+++ b/Tests/Model/IRAssetIdTests.m
@@ -53,7 +53,7 @@ static NSString * const VALID_DOMAIN = @"gmail.com";
 
 - (void)testInvalidAssetNamesWithError {
     for (NSUInteger i = 0; i < INVALID_ASSET_NAMES_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRAssetId> assetId = [IRAssetIdFactory assetIdWithName:INVALID_ASSET_NAMES[i]
                                                            domain:[IRDomainFactory domainWithIdentitifer:VALID_DOMAIN error:nil]
                                                             error:&error];
@@ -84,7 +84,7 @@ static NSString * const VALID_DOMAIN = @"gmail.com";
 
 - (void)testInvalidAssetIdentifierWithError {
     for (NSUInteger i = 0; i < INVALID_ASSET_IDENTIFIERS_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRAssetId> assetId = [IRAssetIdFactory assetWithIdentifier:INVALID_ASSET_IDENTIFIERS[i]
                                                                 error:&error];
         XCTAssertNil(assetId);

--- a/Tests/Model/IRDomainTests.m
+++ b/Tests/Model/IRDomainTests.m
@@ -41,7 +41,7 @@ static NSString * const INVALID_DOMAINS[] = {
 
 - (void)testInvalidDomainsWithError {
     for (NSUInteger i = 0; i < INVALID_DOMAINS_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRDomain> domain = [IRDomainFactory domainWithIdentitifer:INVALID_DOMAINS[i]
                                                                error:&error];
         XCTAssertNil(domain);

--- a/Tests/Model/IRGrantablePermissionTests.m
+++ b/Tests/Model/IRGrantablePermissionTests.m
@@ -23,7 +23,7 @@
 
 - (void)testInvalidGrantablePermissionWithError {
     for (int i = 5; i < 10; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRGrantablePermission> permission = [IRGrantablePermissionFactory permissionWithValue:i
                                                                                            error:&error];
         XCTAssertNil(permission);

--- a/Tests/Model/IRRoleNameTests.m
+++ b/Tests/Model/IRRoleNameTests.m
@@ -43,7 +43,7 @@ static NSString* const INVALID_ROLE_NAMES[] = {
 
 - (void)testInvalidRoleNamesWithError {
     for (NSUInteger i = 0; i < INVALID_ROLE_NAMES_COUNT; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRRoleName> roleName = [IRRoleNameFactory roleWithName:INVALID_ROLE_NAMES[i]
                                                             error:&error];
         XCTAssertNil(roleName);

--- a/Tests/Model/IRRolePermissionTests.m
+++ b/Tests/Model/IRRolePermissionTests.m
@@ -23,7 +23,7 @@
 
 - (void)testInvalidRolPermissionWithError {
     for (int i = 50; i < 60; i++) {
-        NSError *error;
+        NSError *error = nil;
         id<IRRolePermission> permission = [IRRolePermissionFactory permissionWithValue:i
                                                                                  error:&error];
         XCTAssertNil(permission);

--- a/Tests/Query/IRQueryBuilderTests.m
+++ b/Tests/Query/IRQueryBuilderTests.m
@@ -44,7 +44,7 @@ static UInt64 VALID_QUERY_COUNTER = 10;
 - (void)testMissingAccountId {
     IRQueryBuilder *queryBuilder = [[IRQueryBuilder alloc] init];
 
-    NSError *error;
+    NSError *error = nil;
     id<IRQueryRequest> query = [queryBuilder build:&error];
 
     XCTAssertNil(query);
@@ -57,7 +57,7 @@ static UInt64 VALID_QUERY_COUNTER = 10;
 
     IRQueryBuilder *queryBuilder = [IRQueryBuilder builderWithCreatorAccountId:accountId];
 
-    NSError *error;
+    NSError *error = nil;
     id<IRQueryRequest> query = [queryBuilder build:&error];
 
     XCTAssertNil(query);
@@ -91,10 +91,10 @@ static UInt64 VALID_QUERY_COUNTER = 10;
 
         [invocation invoke];
 
-        NSError *error;
+        NSError *error = nil;
         id<IRQueryRequest> queryRequest = [queryBuilder build:&error];
 
-        XCTAssertNil(error);
+        XCTAssertNil(error, "Query builder failed: %@", [error localizedDescription]);
         XCTAssertNotNil(queryRequest);
         XCTAssertEqualObjects([accountId identifier], [queryRequest.creator identifier]);
         XCTAssertEqualObjects(date, queryRequest.createdAt);


### PR DESCRIPTION
When passing error object by reference it should be initialized as nil

Signed-off-by: Russel <emkil.russel@gmail.com>